### PR TITLE
Added Authorize function to OAuthAuthenticator to handle only token exchange

### DIFF
--- a/oauth_test.go
+++ b/oauth_test.go
@@ -67,7 +67,7 @@ func TestOAuthAuthenticatorCallbackHandler(t *testing.T) {
 		}
 	})
 
-	req, _ = http.NewRequest("GET", "", nil)
+	req, _ = http.NewRequest("GET", "?code=75e251e3ff8fff", nil)
 	f(httptest.NewRecorder(), req)
 
 	// strava error
@@ -85,7 +85,7 @@ func TestOAuthAuthenticatorCallbackHandler(t *testing.T) {
 		}
 	})
 
-	req, _ = http.NewRequest("GET", "", nil)
+	req, _ = http.NewRequest("GET", "?code=75e251e3ff8fff", nil)
 	f(httptest.NewRecorder(), req)
 
 	// strava invalid credentials error
@@ -103,7 +103,7 @@ func TestOAuthAuthenticatorCallbackHandler(t *testing.T) {
 		}
 	})
 
-	req, _ = http.NewRequest("GET", "", nil)
+	req, _ = http.NewRequest("GET", "?code=75e251e3ff8fff", nil)
 	f(httptest.NewRecorder(), req)
 
 	// strava invalid code error
@@ -139,7 +139,7 @@ func TestOAuthAuthenticatorCallbackHandler(t *testing.T) {
 		}
 	})
 
-	req, _ = http.NewRequest("GET", "", nil)
+	req, _ = http.NewRequest("GET", "?code=75e251e3ff8fff", nil)
 	f(httptest.NewRecorder(), req)
 
 	// bad json
@@ -172,8 +172,17 @@ func TestOAuthAuthenticatorCallbackHandler(t *testing.T) {
 		t.Error("should be success")
 	})
 
-	req, _ = http.NewRequest("GET", "", nil)
+	req, _ = http.NewRequest("GET", "?code=75e251e3ff8fff", nil)
 	f(httptest.NewRecorder(), req)
+}
+
+func TestOAuthAuthenticatorAuthorize(t *testing.T) {
+	auth := OAuthAuthenticator{}
+
+	_, err := auth.Authorize("", nil)
+	if err != OAuthInvalidCodeErr {
+		t.Error("returned incorrect error, got %v", err)
+	}
 }
 
 func TestOAuthAuthenticatorCallbackPath(t *testing.T) {


### PR DESCRIPTION
The OAuthAuthenticator HandlerFunc is meant to be the redirect_url from the access request. I thought it would be useful to provide a function that uses a provided code from a different redirect url and only handles the token exchange. For example, if your OAuth redirect URL is set to your browser-side JS, which subsequently passes the code to your server-side Strava client.
