### PR TITLE
Store rate limit values and allow checking if limit was reached

### DIFF
--- a/ratelimit.go
+++ b/ratelimit.go
@@ -1,0 +1,20 @@
+package strava
+
+var RateLimitLast RateLimit
+
+type RateLimit struct {
+	LimitShort int
+	LimitLong  int
+	UsageShort int
+	UsageLong  int
+}
+
+func RateLimitReached() bool {
+	if RateLimitLast.UsageShort == 0 { // no need to check both values
+		return false
+	} else if RateLimitLast.UsageShort >= RateLimitLast.LimitShort || RateLimitLast.UsageLong >= RateLimitLast.LimitLong {
+		return true
+	} else {
+		return false
+	}
+}

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -1,20 +1,31 @@
 package strava
 
+import (
+	"time"
+)
+
 var RateLimitLast RateLimit
 
 type RateLimit struct {
-	LimitShort int
-	LimitLong  int
-	UsageShort int
-	UsageLong  int
+	LastRequestTime time.Time
+	LimitShort      int
+	LimitLong       int
+	UsageShort      int
+	UsageLong       int
 }
 
-func RateLimitReached() bool {
-	if RateLimitLast.UsageShort == 0 { // no need to check both values
+// returns true if rate limit was reached during last X seconds
+func RateLimitReachedDuringLast(seconds int64) bool {
+	if RateLimitLast.LastRequestTime.IsZero() {
+		// no idea, so we should try
 		return false
-	} else if RateLimitLast.UsageShort >= RateLimitLast.LimitShort || RateLimitLast.UsageLong >= RateLimitLast.LimitLong {
-		return true
+	} else if RateLimitLast.LastRequestTime.Unix() < (time.Now().Unix() - seconds) {
+		// last request was some time ago, so we should try
+		return false
+	} else if RateLimitLast.UsageShort < RateLimitLast.LimitShort && RateLimitLast.UsageLong < RateLimitLast.LimitLong {
+		// limit not reached
+		return false
 	} else {
-		return false
+		return true
 	}
 }

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -1,6 +1,10 @@
 package strava
 
 import (
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -28,4 +32,32 @@ func RateLimitReachedDuringLast(seconds int64) bool {
 	} else {
 		return true
 	}
+}
+
+func updateRateLimits(resp *http.Response) error {
+	var err error
+
+	if resp.Header.Get("X-Ratelimit-Limit") == "" || resp.Header.Get("X-Ratelimit-Usage") == "" {
+		return errors.New("ratelimit headers not found")
+	}
+
+	s := strings.Split(resp.Header.Get("X-Ratelimit-Limit"), ",")
+	if RateLimitLast.LimitShort, err = strconv.Atoi(s[0]); err != nil {
+		return err
+	}
+	if RateLimitLast.LimitLong, err = strconv.Atoi(s[1]); err != nil {
+		return err
+	}
+
+	s = strings.Split(resp.Header.Get("X-Ratelimit-Usage"), ",")
+	if RateLimitLast.UsageShort, err = strconv.Atoi(s[0]); err != nil {
+		return err
+	}
+	if RateLimitLast.UsageLong, err = strconv.Atoi(s[1]); err != nil {
+		return err
+	}
+
+	RateLimitLast.LastRequestTime = time.Now()
+
+	return nil
 }

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -33,7 +33,7 @@ func RateLimitReachedDuringLast(seconds int64) bool {
 	}
 }
 
-// ignoring error, inster will reset struct to initial values, so rate limiting is ignored
+// ignoring error, instead will reset struct to initial values, so rate limiting is ignored
 func updateRateLimits(resp *http.Response) {
 	var err error
 

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -1,7 +1,6 @@
 package strava
 
 import (
-	"errors"
 	"net/http"
 	"strconv"
 	"strings"
@@ -34,30 +33,34 @@ func RateLimitReachedDuringLast(seconds int64) bool {
 	}
 }
 
-func updateRateLimits(resp *http.Response) error {
+// ignoring error, inster will reset struct to initial values, so rate limiting is ignored
+func updateRateLimits(resp *http.Response) {
 	var err error
 
 	if resp.Header.Get("X-Ratelimit-Limit") == "" || resp.Header.Get("X-Ratelimit-Usage") == "" {
-		return errors.New("ratelimit headers not found")
+		RateLimitLast = RateLimit{}
+		return
 	}
 
 	s := strings.Split(resp.Header.Get("X-Ratelimit-Limit"), ",")
 	if RateLimitLast.LimitShort, err = strconv.Atoi(s[0]); err != nil {
-		return err
+		RateLimitLast = RateLimit{}
+		return
 	}
 	if RateLimitLast.LimitLong, err = strconv.Atoi(s[1]); err != nil {
-		return err
+		RateLimitLast = RateLimit{}
+		return
 	}
 
 	s = strings.Split(resp.Header.Get("X-Ratelimit-Usage"), ",")
 	if RateLimitLast.UsageShort, err = strconv.Atoi(s[0]); err != nil {
-		return err
+		RateLimitLast = RateLimit{}
+		return
 	}
 	if RateLimitLast.UsageLong, err = strconv.Atoi(s[1]); err != nil {
-		return err
+		RateLimitLast = RateLimit{}
+		return
 	}
 
 	RateLimitLast.LastRequestTime = time.Now()
-
-	return nil
 }

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -41,28 +41,28 @@ func (ratelimit *RateLimit) updateRateLimits(resp *http.Response) {
 	var err error
 
 	if resp.Header.Get("X-Ratelimit-Limit") == "" || resp.Header.Get("X-Ratelimit-Usage") == "" {
-		ratelimit.NextRequestTime = time.Time{}
+		ratelimit = &RateLimit{}
 		return
 	}
 
 	s := strings.Split(resp.Header.Get("X-Ratelimit-Limit"), ",")
 	if ratelimit.LimitShort, err = strconv.Atoi(s[0]); err != nil {
-		ratelimit.NextRequestTime = time.Time{}
+		ratelimit = &RateLimit{}
 		return
 	}
 	if ratelimit.LimitLong, err = strconv.Atoi(s[1]); err != nil {
-		ratelimit.NextRequestTime = time.Time{}
+		ratelimit = &RateLimit{}
 		return
 	}
 
 	s = strings.Split(resp.Header.Get("X-Ratelimit-Usage"), ",")
 	if ratelimit.UsageShort, err = strconv.Atoi(s[0]); err != nil {
-		ratelimit.NextRequestTime = time.Time{}
+		ratelimit = &RateLimit{}
 		return
 	}
 
 	if ratelimit.UsageLong, err = strconv.Atoi(s[1]); err != nil {
-		ratelimit.NextRequestTime = time.Time{}
+		ratelimit = &RateLimit{}
 		return
 	}
 

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -7,54 +7,72 @@ import (
 	"time"
 )
 
-var RateLimitingNextRequest time.Time
+type RateLimit struct {
+	NextRequestTime time.Time
+	LimitShort      int
+	LimitLong       int
+	UsageShort      int
+	UsageLong       int
+}
 
-func CanDoRequest() bool {
-	if time.Now().After(RateLimitingNextRequest) {
-		return true
-	} else {
+var RateLimiting RateLimit
+
+func (ratelimit *RateLimit) Exceeded() bool {
+	if time.Now().After(ratelimit.NextRequestTime) {
 		return false
+	} else {
+		return true
+	}
+}
+
+func (ratelimit *RateLimit) FractionReached() float32 {
+	var shortLimitReached float32 = float32(ratelimit.UsageShort) / float32(ratelimit.LimitShort)
+	var longLimitReached float32 = float32(ratelimit.UsageLong) / float32(ratelimit.LimitLong)
+
+	if shortLimitReached > longLimitReached {
+		return shortLimitReached
+	} else {
+		return longLimitReached
 	}
 }
 
 // ignoring error, instead will reset struct to initial values, so rate limiting is ignored
-func updateRateLimits(resp *http.Response) {
+func (ratelimit *RateLimit) updateRateLimits(resp *http.Response) {
+	var err error
+
 	if resp.Header.Get("X-Ratelimit-Limit") == "" || resp.Header.Get("X-Ratelimit-Usage") == "" {
-		RateLimitingNextRequest = time.Time{}
+		ratelimit.NextRequestTime = time.Time{}
 		return
 	}
 
 	s := strings.Split(resp.Header.Get("X-Ratelimit-Limit"), ",")
-	limitShort, err := strconv.Atoi(s[0])
-	if err != nil {
-		RateLimitingNextRequest = time.Time{}
+	if ratelimit.LimitShort, err = strconv.Atoi(s[0]); err != nil {
+		ratelimit.NextRequestTime = time.Time{}
 		return
 	}
-	limitLong, err := strconv.Atoi(s[1])
-	if err != nil {
-		RateLimitingNextRequest = time.Time{}
+	if ratelimit.LimitLong, err = strconv.Atoi(s[1]); err != nil {
+		ratelimit.NextRequestTime = time.Time{}
 		return
 	}
 
 	s = strings.Split(resp.Header.Get("X-Ratelimit-Usage"), ",")
-	usageShort, err := strconv.Atoi(s[0])
-	if err != nil {
-		RateLimitingNextRequest = time.Time{}
+	if ratelimit.UsageShort, err = strconv.Atoi(s[0]); err != nil {
+		ratelimit.NextRequestTime = time.Time{}
 		return
 	}
-	usageLong, err := strconv.Atoi(s[1])
-	if err != nil {
-		RateLimitingNextRequest = time.Time{}
+
+	if ratelimit.UsageLong, err = strconv.Atoi(s[1]); err != nil {
+		ratelimit.NextRequestTime = time.Time{}
 		return
 	}
 
 	currentServerTime, err := time.Parse(http.TimeFormat, resp.Header.Get("Date"))
 	if err != nil {
-		RateLimitingNextRequest = time.Time{}
-	} else if usageShort >= limitShort {
-		RateLimitingNextRequest = getNextRateLimitShort(time.Now(), currentServerTime)
-	} else if usageLong >= limitLong {
-		RateLimitingNextRequest = getNextRateLimitLong(time.Now(), currentServerTime)
+		ratelimit.NextRequestTime = time.Time{}
+	} else if ratelimit.UsageShort >= ratelimit.LimitShort {
+		ratelimit.NextRequestTime = getNextRateLimitShort(time.Now(), currentServerTime)
+	} else if ratelimit.UsageLong >= ratelimit.LimitLong {
+		ratelimit.NextRequestTime = getNextRateLimitLong(time.Now(), currentServerTime)
 	}
 }
 

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -26,13 +26,13 @@ func (ratelimit *RateLimit) Exceeded() bool {
 }
 
 func (ratelimit *RateLimit) FractionReached() float32 {
-	var shortLimitReached float32 = float32(ratelimit.UsageShort) / float32(ratelimit.LimitShort)
-	var longLimitReached float32 = float32(ratelimit.UsageLong) / float32(ratelimit.LimitLong)
+	var shortLimitFraction float32 = float32(ratelimit.UsageShort) / float32(ratelimit.LimitShort)
+	var longLimitFraction float32 = float32(ratelimit.UsageLong) / float32(ratelimit.LimitLong)
 
-	if shortLimitReached > longLimitReached {
-		return shortLimitReached
+	if shortLimitFraction > longLimitFraction {
+		return shortLimitFraction
 	} else {
-		return longLimitReached
+		return longLimitFraction
 	}
 }
 

--- a/ratelimit_test.go
+++ b/ratelimit_test.go
@@ -1,0 +1,77 @@
+package strava
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestRateLimitUpdating(t *testing.T) {
+	var resp http.Response
+
+	resp.StatusCode = 200
+	resp.Header = http.Header{"X-Ratelimit-Limit": []string{"600,30000"}, "X-Ratelimit-Usage": []string{"50,20000"}}
+	updateRateLimits(&resp)
+
+	// not comparing time
+	expected := RateLimit{LimitShort: 600, LimitLong: 30000, UsageShort: 50, UsageLong: 20000, LastRequestTime: RateLimitLast.LastRequestTime}
+
+	if !reflect.DeepEqual(RateLimitLast, expected) {
+		t.Errorf("should match\n%v\n%v", RateLimitLast, expected)
+	}
+
+	if RateLimitLast.LastRequestTime.IsZero() {
+		t.Errorf("rate limiting didn't set non-zero time")
+	}
+
+	// we'll feed it nonsense
+	resp.Header = http.Header{"X-Ratelimit-Limit": []string{"xxx"}, "X-Ratelimit-Usage": []string{"zzz"}}
+	updateRateLimits(&resp)
+
+	expected = RateLimit{}
+
+	if !reflect.DeepEqual(RateLimitLast, expected) {
+		t.Errorf("should match\n%v\n%v", RateLimitLast, expected)
+	}
+
+	// fill it with real values and then test missing headers
+	resp.Header = http.Header{"X-Ratelimit-Limit": []string{"600,30000"}, "X-Ratelimit-Usage": []string{"50,20000"}}
+	updateRateLimits(&resp)
+	resp.Header = http.Header{}
+	updateRateLimits(&resp)
+
+	if !reflect.DeepEqual(RateLimitLast, expected) {
+		t.Errorf("should match\n%v\n%v", RateLimitLast, expected)
+	}
+}
+
+func TestRateLimitChecking(t *testing.T) {
+	var resp http.Response
+
+	resp.StatusCode = 200
+	resp.Header = http.Header{"X-Ratelimit-Limit": []string{"600,30000"}, "X-Ratelimit-Usage": []string{"50,20000"}}
+	updateRateLimits(&resp)
+
+	if RateLimitReachedDuringLast(60) {
+		t.Errorf("rate limit reached when it shouldn't have been")
+	}
+
+	resp.Header = http.Header{"X-Ratelimit-Limit": []string{"600,30000"}, "X-Ratelimit-Usage": []string{"650,20000"}}
+	updateRateLimits(&resp)
+
+	if !RateLimitReachedDuringLast(60) {
+		t.Errorf("rate limit not reached when it should have been")
+	}
+
+	// if rate limit was triggered before "future", it must be expired by now
+	if RateLimitReachedDuringLast(-5) {
+		t.Errorf("rate limit not reached when it should have been")
+	}
+
+	resp.Header = http.Header{"X-Ratelimit-Limit": []string{"nonsense"}, "X-Ratelimit-Usage": []string{"EPO"}}
+	updateRateLimits(&resp)
+
+	if RateLimitReachedDuringLast(60) {
+		t.Errorf("rate limit not reached when it should have been")
+	}
+}

--- a/ratelimit_test.go
+++ b/ratelimit_test.go
@@ -2,76 +2,148 @@ package strava
 
 import (
 	"net/http"
-	"reflect"
 	"testing"
+	"time"
 )
 
 func TestRateLimitUpdating(t *testing.T) {
 	var resp http.Response
 
 	resp.StatusCode = 200
-	resp.Header = http.Header{"X-Ratelimit-Limit": []string{"600,30000"}, "X-Ratelimit-Usage": []string{"50,20000"}}
+	resp.Header = http.Header{"Date": []string{"Tue, 10 Oct 2013 20:11:05 GMT"}, "X-Ratelimit-Limit": []string{"600,30000"}, "X-Ratelimit-Usage": []string{"50,20000"}}
 	updateRateLimits(&resp)
 
-	// not comparing time
-	expected := RateLimit{LimitShort: 600, LimitLong: 30000, UsageShort: 50, UsageLong: 20000, LastRequestTime: RateLimitLast.LastRequestTime}
-
-	if !reflect.DeepEqual(RateLimitLast, expected) {
-		t.Errorf("should match\n%v\n%v", RateLimitLast, expected)
-	}
-
-	if RateLimitLast.LastRequestTime.IsZero() {
-		t.Errorf("rate limiting didn't set non-zero time")
+	if !RateLimitingNextRequest.IsZero() {
+		t.Errorf("rate limiting didn't set zero time", RateLimitingNextRequest) // non-zero is set only when rate limit is reached
 	}
 
 	// we'll feed it nonsense
-	resp.Header = http.Header{"X-Ratelimit-Limit": []string{"xxx"}, "X-Ratelimit-Usage": []string{"zzz"}}
+	resp.Header = http.Header{"Date": []string{"Tue, 10 Oct 2013 20:11:05 GMT"}, "X-Ratelimit-Limit": []string{"xxx"}, "X-Ratelimit-Usage": []string{"zzz"}}
 	updateRateLimits(&resp)
 
-	expected = RateLimit{}
-
-	if !reflect.DeepEqual(RateLimitLast, expected) {
-		t.Errorf("should match\n%v\n%v", RateLimitLast, expected)
+	if !RateLimitingNextRequest.IsZero() {
+		t.Errorf("nonsense in rate limiting fields should set next reset to zero")
 	}
 
-	// fill it with real values and then test missing headers
-	resp.Header = http.Header{"X-Ratelimit-Limit": []string{"600,30000"}, "X-Ratelimit-Usage": []string{"50,20000"}}
-	updateRateLimits(&resp)
-	resp.Header = http.Header{}
+	// rate limit reached - short
+	resp.Header = http.Header{"Date": []string{"Tue, 10 Oct 2013 20:11:05 GMT"}, "X-Ratelimit-Limit": []string{"600,30000"}, "X-Ratelimit-Usage": []string{"650,20000"}}
 	updateRateLimits(&resp)
 
-	if !reflect.DeepEqual(RateLimitLast, expected) {
-		t.Errorf("should match\n%v\n%v", RateLimitLast, expected)
+	if RateLimitingNextRequest.IsZero() {
+		t.Errorf("reaching rate limit should set non-zero value", RateLimitingNextRequest)
+	}
+
+	// rate limit reached - long
+	resp.Header = http.Header{"Date": []string{"Tue, 10 Oct 2013 20:11:05 GMT"}, "X-Ratelimit-Limit": []string{"600,30000"}, "X-Ratelimit-Usage": []string{"550,40000"}}
+	updateRateLimits(&resp)
+
+	if RateLimitingNextRequest.IsZero() {
+		t.Errorf("reaching rate limit should set non-zero value", RateLimitingNextRequest)
 	}
 }
 
+func TestNextRateLimit(t *testing.T) {
+	// SHORT
+	// normal time
+	currentTime, err := time.Parse(http.TimeFormat, "Tue, 10 Oct 2013 20:11:05 GMT")
+	if err != nil {
+		t.Errorf("error parsing date")
+	}
+	expectedTime, err := time.Parse(http.TimeFormat, "Tue, 10 Oct 2013 20:15:00 GMT")
+	if err != nil {
+		t.Errorf("error parsing date")
+	}
+	nextRequestTime := getNextRateLimitShort(currentTime, currentTime)
+	if expectedTime != nextRequestTime {
+		t.Errorf("didn't set correct next request time\n%v\n%v", expectedTime, nextRequestTime)
+	}
+
+	// lowest time
+	currentTime, err = time.Parse(http.TimeFormat, "Tue, 10 Oct 2013 00:00:01 GMT")
+	if err != nil {
+		t.Errorf("error parsing date")
+	}
+	expectedTime, err = time.Parse(http.TimeFormat, "Tue, 10 Oct 2013 00:15:00 GMT")
+	if err != nil {
+		t.Errorf("error parsing date")
+	}
+	nextRequestTime = getNextRateLimitShort(currentTime, currentTime)
+	if expectedTime != nextRequestTime {
+		t.Errorf("didn't set correct next request time\n%v\n%v", expectedTime, nextRequestTime)
+	}
+
+	// highest time
+	currentTime, err = time.Parse(http.TimeFormat, "Tue, 10 Oct 2013 23:59:59 GMT")
+	if err != nil {
+		t.Errorf("error parsing date")
+	}
+	expectedTime, err = time.Parse(http.TimeFormat, "Tue, 11 Oct 2013 00:00:00 GMT")
+	if err != nil {
+		t.Errorf("error parsing date")
+	}
+	nextRequestTime = getNextRateLimitShort(currentTime, currentTime)
+	if expectedTime != nextRequestTime {
+		t.Errorf("didn't set correct next request time\n%v\n%v", expectedTime, nextRequestTime)
+	}
+
+	// LONG
+	// normal time
+	currentTime, err = time.Parse(http.TimeFormat, "Tue, 10 Oct 2013 20:11:05 GMT")
+	if err != nil {
+		t.Errorf("error parsing date")
+	}
+	expectedTime, err = time.Parse(http.TimeFormat, "Tue, 11 Oct 2013 00:00:00 GMT")
+	if err != nil {
+		t.Errorf("error parsing date")
+	}
+	nextRequestTime = getNextRateLimitLong(currentTime, currentTime)
+	if expectedTime != nextRequestTime {
+		t.Errorf("didn't set correct next request time\n%v\n%v", expectedTime, nextRequestTime)
+	}
+
+	// lowest time
+	currentTime, err = time.Parse(http.TimeFormat, "Tue, 10 Oct 2013 00:00:01 GMT")
+	if err != nil {
+		t.Errorf("error parsing date")
+	}
+	expectedTime, err = time.Parse(http.TimeFormat, "Tue, 11 Oct 2013 00:00:00 GMT")
+	if err != nil {
+		t.Errorf("error parsing date")
+	}
+	nextRequestTime = getNextRateLimitLong(currentTime, currentTime)
+	if expectedTime != nextRequestTime {
+		t.Errorf("didn't set correct next request time\n%v\n%v", expectedTime, nextRequestTime)
+	}
+
+	// highest time
+	currentTime, err = time.Parse(http.TimeFormat, "Tue, 10 Oct 2013 23:59:59 GMT")
+	if err != nil {
+		t.Errorf("error parsing date")
+	}
+	expectedTime, err = time.Parse(http.TimeFormat, "Tue, 11 Oct 2013 00:00:00 GMT")
+	if err != nil {
+		t.Errorf("error parsing date")
+	}
+	nextRequestTime = getNextRateLimitLong(currentTime, currentTime)
+	if expectedTime != nextRequestTime {
+		t.Errorf("didn't set correct next request time\n%v\n%v", expectedTime, nextRequestTime)
+	}
+
+}
+
 func TestRateLimitChecking(t *testing.T) {
-	var resp http.Response
-
-	resp.StatusCode = 200
-	resp.Header = http.Header{"X-Ratelimit-Limit": []string{"600,30000"}, "X-Ratelimit-Usage": []string{"50,20000"}}
-	updateRateLimits(&resp)
-
-	if RateLimitReachedDuringLast(60) {
-		t.Errorf("rate limit reached when it shouldn't have been")
+	RateLimitingNextRequest = time.Time{}
+	if CanDoRequest() == false {
+		t.Errorf("rate limiting didn't allow request but should have")
 	}
 
-	resp.Header = http.Header{"X-Ratelimit-Limit": []string{"600,30000"}, "X-Ratelimit-Usage": []string{"650,20000"}}
-	updateRateLimits(&resp)
-
-	if !RateLimitReachedDuringLast(60) {
-		t.Errorf("rate limit not reached when it should have been")
+	RateLimitingNextRequest = time.Now().Add(time.Duration(-5 * time.Second))
+	if CanDoRequest() == false {
+		t.Errorf("rate limiting didn't allow request but should have")
 	}
 
-	// if rate limit was triggered before "future", it must be expired by now
-	if RateLimitReachedDuringLast(-5) {
-		t.Errorf("rate limit not reached when it should have been")
-	}
-
-	resp.Header = http.Header{"X-Ratelimit-Limit": []string{"nonsense"}, "X-Ratelimit-Usage": []string{"EPO"}}
-	updateRateLimits(&resp)
-
-	if RateLimitReachedDuringLast(60) {
-		t.Errorf("rate limit not reached when it should have been")
+	RateLimitingNextRequest = time.Now().Add(time.Duration(5 * time.Second))
+	if CanDoRequest() == true {
+		t.Errorf("rate limiting did allow request but shouldn't have")
 	}
 }

--- a/ratelimit_test.go
+++ b/ratelimit_test.go
@@ -18,7 +18,7 @@ func TestRateLimitUpdating(t *testing.T) {
 	}
 
 	if RateLimiting.FractionReached() != 0.5 {
-		t.Errorf("fraction of rate limit computed incorrectly%v%v", RateLimiting.FractionReached(), 0.5)
+		t.Errorf("fraction of rate limit computed incorrectly: %v != %v", RateLimiting.FractionReached(), 0.5)
 	}
 
 	resp.Header = http.Header{"Date": []string{"Tue, 10 Oct 2013 20:11:05 GMT"}, "X-Ratelimit-Limit": []string{"600,30000"}, "X-Ratelimit-Usage": []string{"300,27000"}}
@@ -29,7 +29,7 @@ func TestRateLimitUpdating(t *testing.T) {
 	}
 
 	if RateLimiting.FractionReached() != 0.9 {
-		t.Errorf("fraction of rate limit computed incorrectly%v%v", RateLimiting.FractionReached(), 0.5)
+		t.Errorf("fraction of rate limit computed incorrectly: %v != %v", RateLimiting.FractionReached(), 0.9)
 	}
 
 	// we'll feed it nonsense

--- a/service.go
+++ b/service.go
@@ -7,9 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
-	"time"
 )
 
 var ClientId int
@@ -106,34 +104,6 @@ func (client *Client) runRequest(req *http.Request) ([]byte, error) {
 	updateRateLimits(resp)
 
 	return checkResponseForErrors(resp)
-}
-
-func updateRateLimits(resp *http.Response) error {
-	var err error
-
-	if resp.Header.Get("X-Ratelimit-Limit") == "" || resp.Header.Get("X-Ratelimit-Usage") == "" {
-		return errors.New("ratelimit headers not found")
-	}
-
-	s := strings.Split(resp.Header.Get("X-Ratelimit-Limit"), ",")
-	if RateLimitLast.LimitShort, err = strconv.Atoi(s[0]); err != nil {
-		return err
-	}
-	if RateLimitLast.LimitLong, err = strconv.Atoi(s[1]); err != nil {
-		return err
-	}
-
-	s = strings.Split(resp.Header.Get("X-Ratelimit-Usage"), ",")
-	if RateLimitLast.UsageShort, err = strconv.Atoi(s[0]); err != nil {
-		return err
-	}
-	if RateLimitLast.UsageLong, err = strconv.Atoi(s[1]); err != nil {
-		return err
-	}
-
-	RateLimitLast.LastRequestTime = time.Now()
-
-	return nil
 }
 
 func checkResponseForErrors(resp *http.Response) ([]byte, error) {

--- a/service.go
+++ b/service.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 )
 
 var ClientId int
@@ -129,6 +130,8 @@ func updateRateLimits(resp *http.Response) error {
 	if RateLimitLast.UsageLong, err = strconv.Atoi(s[1]); err != nil {
 		return err
 	}
+
+	RateLimitLast.LastRequestTime = time.Now()
 
 	return nil
 }

--- a/service.go
+++ b/service.go
@@ -101,7 +101,7 @@ func (client *Client) runRequest(req *http.Request) ([]byte, error) {
 
 	defer resp.Body.Close()
 
-	updateRateLimits(resp)
+	RateLimiting.updateRateLimits(resp)
 
 	return checkResponseForErrors(resp)
 }


### PR DESCRIPTION
If I'm not mistaken, there isn't a way to get http response directly to check rate limiting headers, so this will store them after every request, allow checking them before doing next request and back-off a little if necessary.

I'm golang novice, so maybe the code is a little bit hairy.