### PR TITLE
fixes typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ Related constants:
 	segment, err := service.Get(segmentId).Do()
 
 	// return list of segment efforts
-	efforst, err := service.ListEfforts(segmentId).
+	efforts, err := service.ListEfforts(segmentId).
 		Page(page).
 		PerPage(perPage).
 		AthleteId(athleteId).


### PR DESCRIPTION
Fixes a typo in the readme on line 375.

Previously `efforst, err := service.ListEfforts(segmentId).`,
updated to `efforts, err := service.ListEfforts(segmentId).`