### PR TITLE
Correct scope types to match API docs

### DIFF
--- a/oauth.go
+++ b/oauth.go
@@ -27,15 +27,21 @@ type Permission string
 
 // Permissions defines the available permissions
 var Permissions = struct {
-	Public           Permission
-	ViewPrivate      Permission
-	Write            Permission
-	WriteViewPrivate Permission
+	Read            Permission
+	ReadAll         Permission
+	ProfileReadAll  Permission
+	ProfileWrite    Permission
+	ActivityRead    Permission
+	ActivityReadAll Permission
+	ActivityWrite   Permission
 }{
-	"public",
-	"view_private",
-	"write",
-	"write,view_private",
+	"read",
+	"read_all",
+	"profile:read_all",
+	"profile:write",
+	"activity:read",
+	"activity:read_all",
+	"activity:write",
 }
 
 // AuthorizationResponse is returned as a result of the token exchange

--- a/oauth_test.go
+++ b/oauth_test.go
@@ -215,23 +215,23 @@ func TestOAuthAuthenticatorAuthorizationURL(t *testing.T) {
 		CallbackURL: "http://abc.com/strava/oauth",
 	}
 
-	url := auth.AuthorizationURL("state", Permissions.Public, false)
-	if url != basePath+"/oauth/authorize?client_id=0&response_type=code&redirect_uri=http://abc.com/strava/oauth&scope=public&state=state" {
+	url := auth.AuthorizationURL("state", Permissions.Read, false)
+	if url != basePath+"/oauth/authorize?client_id=0&response_type=code&redirect_uri=http://abc.com/strava/oauth&scope=read&state=state" {
 		t.Errorf("incorrect oauth url, got %v", url)
 	}
 
-	url = auth.AuthorizationURL("state", Permissions.Public, true)
-	if url != basePath+"/oauth/authorize?client_id=0&response_type=code&redirect_uri=http://abc.com/strava/oauth&scope=public&state=state&approval_prompt=force" {
+	url = auth.AuthorizationURL("state", Permissions.Read, true)
+	if url != basePath+"/oauth/authorize?client_id=0&response_type=code&redirect_uri=http://abc.com/strava/oauth&scope=read&state=state&approval_prompt=force" {
 		t.Errorf("incorrect oauth url, got %v", url)
 	}
 
-	url = auth.AuthorizationURL("state", Permissions.ViewPrivate, false)
-	if url != basePath+"/oauth/authorize?client_id=0&response_type=code&redirect_uri=http://abc.com/strava/oauth&scope=view_private&state=state" {
+	url = auth.AuthorizationURL("state", Permissions.ReadAll, false)
+	if url != basePath+"/oauth/authorize?client_id=0&response_type=code&redirect_uri=http://abc.com/strava/oauth&scope=read_all&state=state" {
 		t.Errorf("incorrect oauth url, got %v", url)
 	}
 
-	url = auth.AuthorizationURL("", Permissions.Public, false)
-	if url != basePath+"/oauth/authorize?client_id=0&response_type=code&redirect_uri=http://abc.com/strava/oauth&scope=public" {
+	url = auth.AuthorizationURL("", Permissions.Read, false)
+	if url != basePath+"/oauth/authorize?client_id=0&response_type=code&redirect_uri=http://abc.com/strava/oauth&scope=read" {
 		t.Errorf("incorrect oauth url, got %v", url)
 	}
 }


### PR DESCRIPTION
The permission scopes no longer match the documentation. The permission scopes are documented here: https://developers.strava.com/docs/authentication/#detailsaboutrequestingaccess